### PR TITLE
Update type to reflected that the awaited value is stored

### DIFF
--- a/README.md
+++ b/README.md
@@ -277,7 +277,7 @@ async function fetchProductDetails(productId: string): Promise<Product> {
 
 const productId = 'product-123456'
 
-const result = await swr<Product>(productId, async () =>
+const result = await swr<Promise<Product>>(productId, async () =>
   fetchProductDetails(productId)
 )
 

--- a/README.md
+++ b/README.md
@@ -277,7 +277,7 @@ async function fetchProductDetails(productId: string): Promise<Product> {
 
 const productId = 'product-123456'
 
-const result = await swr<Promise<Product>>(productId, async () =>
+const result = await swr<Product>(productId, async () =>
   fetchProductDetails(productId)
 )
 

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -60,7 +60,7 @@ describe('createStaleWhileRevalidateCache', () => {
       const key = 'key'
       const value = 'value'
       const fn = jest.fn(async () => value)
-      const result = await swr(key, async () => await fn())
+      const result = await swr<string>(key, async () => await fn())
 
       expect(result).toMatchObject({
         value,

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -59,8 +59,8 @@ describe('createStaleWhileRevalidateCache', () => {
       const swr = createStaleWhileRevalidateCache(validConfig)
       const key = 'key'
       const value = 'value'
-      const fn = jest.fn(() => value)
-      const result = await swr(key, fn)
+      const fn = jest.fn(async () => value)
+      const result = await swr(key, async () => await fn())
 
       expect(result).toMatchObject({
         value,

--- a/src/index.ts
+++ b/src/index.ts
@@ -77,7 +77,7 @@ export function createStaleWhileRevalidateCache(
     cacheKey: IncomingCacheKey,
     fn: () => FunctionReturnValue,
     configOverrides?: Partial<Config>
-  ): Promise<ResponseEnvelope<FunctionReturnValue>> {
+  ): Promise<ResponseEnvelope<Awaited<FunctionReturnValue>>> {
     const { storage, minTimeToStale, maxTimeToLive, serialize, deserialize } =
       configOverrides
         ? parseConfig({ ...cacheConfig, ...configOverrides })
@@ -184,7 +184,7 @@ export function createStaleWhileRevalidateCache(
         now,
         staleAt: cachedAt + minTimeToStale,
         status: cacheStatus,
-        value: cachedValue as FunctionReturnValue,
+        value: cachedValue as Awaited<FunctionReturnValue>,
       }
     }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -73,11 +73,11 @@ export function createStaleWhileRevalidateCache(
     }
   }
 
-  async function staleWhileRevalidate<FunctionReturnValue>(
+  async function staleWhileRevalidate<CacheValue>(
     cacheKey: IncomingCacheKey,
-    fn: () => FunctionReturnValue,
+    fn: () => CacheValue | Promise<CacheValue>,
     configOverrides?: Partial<Config>
-  ): Promise<ResponseEnvelope<Awaited<FunctionReturnValue>>> {
+  ): Promise<ResponseEnvelope<Awaited<CacheValue>>> {
     const { storage, minTimeToStale, maxTimeToLive, serialize, deserialize } =
       configOverrides
         ? parseConfig({ ...cacheConfig, ...configOverrides })
@@ -184,7 +184,7 @@ export function createStaleWhileRevalidateCache(
         now,
         staleAt: cachedAt + minTimeToStale,
         status: cacheStatus,
-        value: cachedValue as Awaited<FunctionReturnValue>,
+        value: cachedValue as Awaited<CacheValue>,
       }
     }
 

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -32,7 +32,7 @@ export type StaleWhileRevalidateCache = <FunctionReturnValue>(
   cacheKey: IncomingCacheKey,
   fn: () => FunctionReturnValue,
   configOverrides?: Partial<Config>
-) => Promise<ResponseEnvelope<FunctionReturnValue>>
+) => Promise<ResponseEnvelope<Awaited<FunctionReturnValue>>>
 
 export type StaticMethods = {
   delete: (cacheKey: IncomingCacheKey) => Promise<void>

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -28,11 +28,11 @@ export type ResponseEnvelope<CacheValue> = {
   staleAt: number
 }
 
-export type StaleWhileRevalidateCache = <FunctionReturnValue>(
+export type StaleWhileRevalidateCache = <CacheValue>(
   cacheKey: IncomingCacheKey,
-  fn: () => FunctionReturnValue,
+  fn: () => CacheValue | Promise<CacheValue>,
   configOverrides?: Partial<Config>
-) => Promise<ResponseEnvelope<Awaited<FunctionReturnValue>>>
+) => Promise<ResponseEnvelope<Awaited<CacheValue>>>
 
 export type StaticMethods = {
   delete: (cacheKey: IncomingCacheKey) => Promise<void>


### PR DESCRIPTION
The types says that the return value of the provided function is stored in the cache. This works fine for non async functions but if a async function is provided this will result in the stored value is a promise and not the value the promise will resolve.

Since the provided function is always awaited the `Awaited` type can be used to get the resolved value of a promise.

Fixes https://github.com/jperasmus/stale-while-revalidate-cache/issues/26

Also update the type in the readme example so it doesn't generate an error, but maybe it should just be removed since it will be correctly inferred by TypeScript.