### PR TITLE
handle a bug with cache miss always triggering a cache get failed error

### DIFF
--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -160,7 +160,6 @@ describe('createStaleWhileRevalidateCache', () => {
       expect(mockedLocalStorage.getItem(key)).toEqual(JSON.stringify(value))
     })
 
-
     it('should not revalidate if the value is cached and still fresh', async () => {
       // Set minTimeToStale to 1 second so that the cache is fresh for second invocation
       const swr = createStaleWhileRevalidateCache({

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -104,7 +104,7 @@ describe('createStaleWhileRevalidateCache', () => {
       })
       expect(fn).toHaveBeenCalledTimes(1)
       expect(customSerialize).toHaveBeenCalledTimes(1)
-      expect(customDeserialize).toHaveBeenCalledTimes(1)
+      expect(customDeserialize).toHaveBeenCalledTimes(0)
       expect(mockedLocalStorage.getItem(key)).toEqual(JSON.stringify(value))
     })
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -133,11 +133,12 @@ export function createStaleWhileRevalidateCache(
           storage.getItem(timeKey),
         ])
 
-        cachedValue = deserialize(cachedValue)
-
         if (isNil(cachedValue) || isNil(cachedAt)) {
           return { cachedValue: null, cachedAge: 0, now }
         }
+
+        cachedValue = deserialize(cachedValue)
+
         const cachedAge = now - Number(cachedAt)
 
         if (cachedAge > maxTimeToLive) {


### PR DESCRIPTION
Hi, 

Myself and @antonioguerra noticed a bug with cache miss always triggering a cache get failed error, we think its because when you try and deserialise undefined (in our case using JSON.parse) it throws an error.

This fix moves the deserialise call after the isNil checks.

Paul