### PR TITLE
Feature/persist with options

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ const storage = {
   async getItem(cacheKey: string) {
     return redis.get(cacheKey)
   },
-  async setItem(cacheKey: string, cacheValue: any) {
+  async setItem(cacheKey: string, cacheValue: any, additionalOptions: StorageOptions) {
     // Use px or ex depending on whether you use milliseconds or seconds for your ttl
     // It is recommended to set ttl to your maxTimeToLive (it has to be more than it)
     await redis.set(cacheKey, cacheValue, 'px', ttl)
@@ -177,6 +177,16 @@ const result = await swr.persist(cacheKey, cacheValue)
 ```
 
 The value will be passed through the `serialize` method you optionally provided when you instantiated the `swr` helper.
+
+Additional options can be passed as a third argument and propagated to the storage's `setItem` method.
+
+```typescript
+const cacheKey = 'your-cache-key'
+const cacheValue = { something: 'useful' }
+const additionalOptions = { overrideOption: 1000 }
+const result = await swr.persist(cacheKey, cacheValue, additionalOptions)
+```
+
 
 #### Manually read from cache
 

--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ const storage = {
   async getItem(cacheKey: string) {
     return redis.get(cacheKey)
   },
-  async setItem(cacheKey: string, cacheValue: any, additionalOptions: StorageOptions) {
+  async setItem(cacheKey: string, cacheValue: any, persistOptions: PersistOptions) {
     // Use px or ex depending on whether you use milliseconds or seconds for your ttl
     // It is recommended to set ttl to your maxTimeToLive (it has to be more than it)
     await redis.set(cacheKey, cacheValue, 'px', ttl)
@@ -183,8 +183,8 @@ Additional options can be passed as a third argument and propagated to the stora
 ```typescript
 const cacheKey = 'your-cache-key'
 const cacheValue = { something: 'useful' }
-const additionalOptions = { overrideOption: 1000 }
-const result = await swr.persist(cacheKey, cacheValue, additionalOptions)
+const persistOptions = { overrideOption: 1000 }
+const result = await swr.persist(cacheKey, cacheValue, persistOptions)
 ```
 
 

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1,6 +1,10 @@
 export interface Storage {
   getItem(key: string): unknown | null | Promise<unknown | null>
-  setItem(key: string, value: unknown): void | Promise<void>
+  setItem(
+    key: string,
+    value: unknown,
+    persistOptions?: PersistOptions
+  ): void | Promise<void>
   removeItem?: (key: string) => unknown | null | Promise<unknown | null>
   [key: string]: any
 }
@@ -42,6 +46,8 @@ export type ResponseEnvelope<CacheValue> = {
   staleAt: number
 }
 
+export type PersistOptions = Record<string, any>
+
 export type StaleWhileRevalidateCache = <CacheValue>(
   cacheKey: IncomingCacheKey,
   fn: () => CacheValue | Promise<CacheValue>,
@@ -55,6 +61,7 @@ export type StaticMethods = {
   ) => Promise<RetrieveCachedValueResponse<CacheValue>>
   persist: <CacheValue>(
     cacheKey: IncomingCacheKey,
-    cacheValue: CacheValue
+    cacheValue: CacheValue,
+    persistOptions?: PersistOptions
   ) => Promise<void>
 }


### PR DESCRIPTION
### Motivation
Allow defining custom options for manual data persisting.

### Example scenario: 
A developer may not want to expose globally both SWR and Cache Storage,  but still need to persist data with different ttl or other configurations.
