### PR TITLE
make time cache key less likely to collide with real keys

### DIFF
--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -17,7 +17,7 @@ export const isPlainObject = (value: unknown) =>
 export const getCacheKey = (cacheKey: IncomingCacheKey) =>
   isFunction(cacheKey) ? String(cacheKey()) : String(cacheKey)
 
-export const createTimeCacheKey = (cacheKey: string) => `${cacheKey}_time`
+export const createTimeCacheKey = (cacheKey: string) => `${cacheKey}__swr_time__`
 
 export const passThrough = (value: unknown) => value
 

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -17,7 +17,8 @@ export const isPlainObject = (value: unknown) =>
 export const getCacheKey = (cacheKey: IncomingCacheKey) =>
   isFunction(cacheKey) ? String(cacheKey()) : String(cacheKey)
 
-export const createTimeCacheKey = (cacheKey: string) => `${cacheKey}__swr_time__`
+export const createTimeCacheKey = (cacheKey: string) =>
+  `${cacheKey}__swr_time__`
 
 export const passThrough = (value: unknown) => value
 


### PR DESCRIPTION
I noticed that you can break the swr behaviour by using a key ending in `_time`.

Example:

```js
const swr = createStaleWhileRevalidateCache({
    minTimeToStale: 5000,
    storage,
})

const getRandom = async () => {
    await new Promise(resolve => setTimeout(resolve, 20))
    return Math.random()
}

const log = ({value, ...rest}) => {
    console.log(value, JSON.stringify(rest))
}

await swr('test', getRandom).then(log)
await swr('test_time', getRandom).then(log)
await swr('test', getRandom).then(log)
await new Promise(resolve => setTimeout(resolve, 1000))
await swr('test', getRandom).then(log)
```

This just makes this less likely to happen by mistake